### PR TITLE
Allows null callable in filter function

### DIFF
--- a/src/CollectionInterface.php
+++ b/src/CollectionInterface.php
@@ -19,7 +19,7 @@ interface CollectionInterface
      * @param callable|null $function ($value, $key)
      * @return Collection
      */
-    public function filter(callable $function = null);
+    public function filter(?callable $function = null);
 
     /**
      * Returns a lazy collection of distinct items. The comparison is the same as in in_array.

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -22,7 +22,7 @@ trait CollectionTrait
      * @param callable|null $function ($value, $key)
      * @return Collection
      */
-    public function filter(callable $function = null)
+    public function filter(?callable $function = null)
     {
         return filter($this->getItems(), $function);
     }

--- a/src/collection_functions.php
+++ b/src/collection_functions.php
@@ -245,7 +245,7 @@ function map($collection, callable $function)
  * @param callable|null $function ($value, $key)
  * @return Collection
  */
-function filter($collection, callable $function = null)
+function filter($collection, ?callable $function = null)
 {
     if (null === $function) {
         $function = function ($value) {


### PR DESCRIPTION
Relaxes the type hint for the callable parameter in the `filter` function and related interface/trait to accept null values.